### PR TITLE
Make benchmark duration customizable

### DIFF
--- a/benchmark.sh
+++ b/benchmark.sh
@@ -2,7 +2,7 @@
 
 SED="sed"
 HEAD="head"
-DURATION=120
+: ${DURATION:=120}
 
 [ "$(uname -s)" == "Darwin" ] && SED=gsed
 [ "$(uname -s)" == "Darwin" ] && HEAD=ghead


### PR DESCRIPTION
Example to use 10s:

     DURATION=10 ./benchmark.sh ...

Signed-off-by: Sutou Kouhei <kou@clear-code.com>